### PR TITLE
#26 get_ets fun

### DIFF
--- a/R/get_funs.R
+++ b/R/get_funs.R
@@ -50,8 +50,8 @@ get_age_hist <- function(date_hist, date_birth, round_val = 2) {
 #'
 #' @param data Input `data.frame`.
 #' @param var Name of variable (`character`) that contains the electoral term values.
-#' @param dummy
-#' @param merge
+#' @param dummy A `logical` value indicating whether to generate dummy variables per electoral term (`TRUE`) or a single `list` variable. Default is `TRUE`.
+#' @param merge A `logical` value indicating whether to return just the generated columns (`FALSE`) or the whole `data.frame` (`TRUE`). Default is `TRUE`.
 #'
 #' @return A `data.frame`.
 #' @importFrom magrittr %>%


### PR DESCRIPTION
- changed `get_lps` to `get_ets` (consistent treatment of internal names as abbreviation of electoral term)
- designed `get_ets` analogously to `get_profession_groups`, but offer more flexibility:

1. function offers option to choose (`dummy` parameter) whether the output format is in dummy form or a list (that is a `data.frame `column)
`2. merge` parameter either returns the whole input data frame including the newly generated columns or just the generated column(s) 